### PR TITLE
fix: ammo randomization after viewing tooltip of quiver

### DIFF
--- a/mod_nested_tooltips/hooks/items/ammo/ammo.nut
+++ b/mod_nested_tooltips/hooks/items/ammo/ammo.nut
@@ -1,0 +1,18 @@
+::NestedTooltips.MH.hook("scripts/items/ammo/ammo", function(q) {
+	q.onEquip = @(__original) function()
+	{
+		// Vanilla always randomizes the ammunition count when a quiver is equipped to something, not player controlled
+		// While displaying tooltips we equip the currently viewed item to the Dummy player, triggering such a randomization allowing the player to generate free ammo
+		// This hook preserves the previous ammunition count in that case
+		if (::MSU.isEqual(this.getContainer().getActor(), ::MSU.getDummyPlayer()))
+		{
+			local oldAmmo = this.m.Ammo;
+			__original();
+			this.m.Ammo = oldAmmo;
+		}
+		else
+		{
+			__original();
+		}
+	}
+});


### PR DESCRIPTION
Currently whenever you view the tooltip of a quiver or powder bag, you automatically randomize the ammunition count in it. This will not be apparent immediately. But as soon as you then move that item to another slot, the ammo count will update.

This is caused because this item is being equipped to the DummyPlayer whenever you view the tooltip of it.
And it is a vanilla rule that if an ammo item is equipped to anyone who is not playercontrolled, then its ammunition count is randomized.

I tested this fix ingame. After the fix I was no longer able to randomize the ammunition count of a powder bag.