### PR TITLE
fix: long tooltips sometimes overlapping with the source div

### DIFF
--- a/ui/mods/msu/nested_tooltips.js
+++ b/ui/mods/msu/nested_tooltips.js
@@ -775,12 +775,17 @@ TooltipModule.prototype.setupUITooltip = function(_targetDIV, _data)
 	if ((offsets.top + containerHeight + offsetY) > wnd.height())
 	{
 		offsets.top = 10;
+
+		// Since the tooltip will now overlap with _targetDIV and cursor, we need to move it to the left or right, depending on where we have the space for it
+		if (targetOffset.left > (wnd.width() / 2))
+		{
+			offsets.left = targetOffset.left - this.mContainer.outerWidth(true);	// We make the right side of the tooltip (this.mContainer) start directly left of the _targetDIV
+		}
+		else
+		{
+			offsets.left = targetOffset.left + _targetDIV.outerWidth(true);	// We make the left side of the tooltip start directly right of the _targetDIV
+		}
 	}
-	// We also move it to the left or right (depending on the half of the screen we're in) to make sure it's not overlapping the cursor
-	if (targetOffset.left > (wnd.width() / 2))
-		offsets.left = targetOffset.left + _targetDIV.outerWidth(true) - this.mContainer.outerWidth(true);
-	else
-		offsets.left = targetOffset.left;
 
 	this.mContainer.css(offsets);
 }


### PR DESCRIPTION
The previous code had weird/wrong calculation. Either those broke at some point or they never worked to begin with.
This issue becomes apparent, when you play on lower resolutions/window mode and view very long tooltips (e.g. weapon tooltips in shops)
When the tooltip doesnt fit above or below the weapon, then you will get usability issues

The previous code also applied its horizontal offset adjustments **always**. Now they are only applied if an actual overlap is imminent

# Before
![image](https://github.com/user-attachments/assets/fd5a522f-9fe7-41a2-bfa1-dabb20ae5082)

![image](https://github.com/user-attachments/assets/3a9cce24-9b0d-4223-a7ed-d2bfd91fdb2e)

# After
![image](https://github.com/user-attachments/assets/06854683-0d7d-454f-8597-4c108eae75c3)

![image](https://github.com/user-attachments/assets/1d0582e5-49e6-48ed-8428-2f8a3895c288)
