### PR TITLE
Better item handling for nested tooltips

### DIFF
--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -19,7 +19,6 @@
 		local entityId = "entityId" in _data ? _data.entityId : null;
 		// local skillId = "skillId" in _data ? _data.skillId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
-		local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
 
 		local skillId = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename].getID();
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
@@ -37,7 +36,15 @@
 		local item;
 		if (itemId != null)
 		{
-			item = this.getItemByItemOwner(entityId, itemId, itemOwner);
+			local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
+			if (itemOwner == null)
+			{
+				item = ::NestedTooltips.NestedTooltipItems[itemId];
+			}
+			else
+			{
+				item = this.getItemByItemOwner(entityId, itemId, itemOwner);
+			}
 		}
 
 		if (!::MSU.isNull(item))
@@ -75,8 +82,10 @@
 		{
 			skill = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename];
 			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
+			skill.m.Item = item;
 			ret = getNestedTooltip_safe(skill);
 			skill.m.Container = null;
+			skill.m.Item = null;
 		}
 
 		return ret;
@@ -89,16 +98,30 @@
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		if (itemId != null)
 		{
-			local entityId = "entityId" in _data ? _data.entityId : null;
 			local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
-			item = this.getItemByItemOwner(entityId, itemId, itemOwner);
+			if (itemOwner == null)
+			{
+				item = ::NestedTooltips.NestedTooltipItems[itemId];
+			}
+			else
+			{
+				item = this.getItemByItemOwner("entityId" in _data ? _data.entityId : null, itemId, itemOwner);
+			}
 		}
 		else
 		{
 			item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.Filename];
+			::NestedTooltips.NestedTooltipItems[item.getInstanceID()] <- ::MSU.asWeakTableRef(item);
 		}
 
 		return item.getNestedTooltip();
+	}
+
+	q.onQueryMSUTooltipData = @() function( _data )
+	{
+		local ret = ::MSU.System.Tooltips.getTooltip(_data.modId, _data.elementId);
+		_data.ExtraData <- ret.Data;
+		return ret.Tooltip.getUIData(_data);
 	}
 
 	q.getItemByItemOwner <- function( _entityId, _itemId, _itemOwner )
@@ -155,25 +178,6 @@
 				break;
 		}
 
-		if (item == null && _itemId != null)
-		{
-			foreach (itemObj in ::MSU.NestedTooltips.ItemObjectsByFilename)
-			{
-				if (itemObj.getInstanceID() == _itemId)
-				{
-					item = itemObj;
-					break;
-				}
-			}
-		}
-
 		return item;
-	}
-
-	q.onQueryMSUTooltipData = @() function( _data )
-	{
-		local ret = ::MSU.System.Tooltips.getTooltip(_data.modId, _data.elementId);
-		_data.ExtraData <- ret.Data;
-		return ret.Tooltip.getUIData(_data);
 	}
 });

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -32,6 +32,10 @@
 				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
 			}
 		}
+		if ("entityId" in _data && typeof _data.entityId == "string")
+		{
+			_data.entityId = _data.entityId.tointeger();
+		}
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
@@ -47,6 +51,10 @@
 				local pair = split(entry, ":");
 				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
 			}
+		}
+		if ("entityId" in _data && typeof _data.entityId == "string")
+		{
+			_data.entityId = _data.entityId.tointeger();
 		}
 		return ::TooltipEvents.general_queryItemNestedTooltipData(_data);
 	}),

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -15,24 +15,24 @@
 	Skill = ::MSU.Class.CustomTooltip(function(_data) {
 		local extraData = split(_data.ExtraData, ",");
 		_data.Filename <- extraData.remove(0);
+		local original_entityId = "entityId" in _data ? _data.entityId : null;
+		_data.entityId <- null;
 		if (extraData.len() != 0)
 		{
 			foreach (entry in extraData)
 			{
 				local pair = split(entry, ":");
+				// Allow the default entityId from the tooltip stack to fall through
+				if (pair[0] == "entityId" && pair[1] == "default")
+				{
+					_data.entityId <- original_entityId;
+					continue;
+				}
+
 				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
 			}
 		}
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
-	}),
-	// Sometimes you need to show the nested tooltip by considering the entity to be null. This is useful for
-	// e.g. showing nested tooltips of StatusEffects inside perk tooltips on the perk tree window when the selected
-	// character has the StatusEffect. Using the standard Skill+filename will show the tooltip of the effect based on that character
-	// whereas we want to show a generic tooltip independent of the entity.
-	NullEntitySkill = ::MSU.Class.CustomTooltip(function(_data) {
-		_data.entityId <- ::MSU.getDummyPlayer().getID();
-		_data.itemOwner <- null;
-		return ::MSU.System.Tooltips.getTooltip(_data.modId, "Skill").Tooltip.getUIData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
 		local extraData = split(_data.ExtraData, ",");

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -37,10 +37,8 @@
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
 		local extraData = split(_data.ExtraData, ",");
 		_data.Filename <- extraData.remove(0);
-		// We want itemId and _itemOwner to be passed via ExtraData only
-		// because a nested item hyperlink shouldn't be considered as the tooltip
-		// of an item that is present on an entity unless specified
-		_data.itemOwner <- null;
+		// We want itemId to be passed via ExtraData only because a nested item hyperlink shouldn't be
+		// considered as the tooltip  of an item that is present on an entity unless specified
 		_data.itemId <- null;
 		if (extraData.len() != 0)
 		{

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -2,7 +2,12 @@
 	ID = "mod_nested_tooltips",
 	Name = "Nested Tooltips Framework",
 	Version = "0.1.13",
-	GitHubURL = "https://github.com/MSUTeam/nested-tooltips"
+	GitHubURL = "https://github.com/MSUTeam/nested-tooltips",
+	NestedTooltipItems = {},
+	function addItemForNestedTooltip( _item )
+	{
+		this.NestedTooltipItems[_item.getInstanceID()] <- ::MSU.asWeakTableRef(_item);
+	}
 }
 
 ::NestedTooltips.MH <- ::Hooks.register(::NestedTooltips.ID, ::NestedTooltips.Version, ::NestedTooltips.Name);


### PR DESCRIPTION
- feat!: improve nested tooltips item handling
  - Require the item with its `InstanceID` to be added to the `::NestedTooltips.NestedTooltipItems` table. `itemOwner` can still be passed in which case we will strictly try to find the item with `itemId` from the specified `itemOwner`. Note: `itemId` in this case always refers to the item object's `InstanceID`.
- feat!: set `entityId` to `null` by default in skill nested tooltip data
  - But the original `entityId` can still be passed through if `entityId:default` is passed in `ExtraData`. Therefore, we delete the `NullEntitySkill` key as that is no longer necessary.