### PR TITLE
Dynamic field from nested object

### DIFF
--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -17,15 +17,22 @@
 		}
 
 		local entityId = "entityId" in _data ? _data.entityId : null;
-		// local skillId = "skillId" in _data ? _data.skillId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
+		local scriptPath = "scripts/skills/" + _data.filename;
+		local className = split(_data.filename, "/").top();
 
-		local skillId = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.filename].getID();
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
 		local skill;
 		if (entity != null)
 		{
-			skill = entity.getSkills().getSkillByID(skillId);
+			foreach (s in entity.getSkills().m.Skills)
+			{
+				if (s.ClassName == className && !s.isGarbage() && !s.isHidden() && ::IO.scriptFilenameByHash(s.ClassNameHash) == scriptPath)
+				{
+					skill = s;
+					break;
+				}
+			}
 		}
 
 		if (skill != null)
@@ -61,7 +68,7 @@
 
 			foreach (s in item.getSkills())
 			{
-				if (s.getID() == skillId)
+				if (::IO.scriptFilenameByHash(s.ClassNameHash) == scriptPath)
 				{
 					ret = getNestedTooltip_safe(s)
 					break;
@@ -80,7 +87,7 @@
 
 		if (ret == null)
 		{
-			skill = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.filename];
+			skill = ::new(scriptPath);
 			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
 			skill.m.Item = item;
 			ret = getNestedTooltip_safe(skill);
@@ -110,7 +117,15 @@
 		}
 		else
 		{
-			item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename];
+			if (_data.filename in ::MSU.NestedTooltips.ItemObjectsByFilename)
+			{
+				item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename];
+			}
+			else
+			{
+				item = ::new("scripts/items/" + _data.filename);
+				::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename] <- item;
+			}
 			::NestedTooltips.NestedTooltipItems[item.getInstanceID()] <- ::MSU.asWeakTableRef(item);
 		}
 

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -18,7 +18,7 @@
 
 		local entityId = "entityId" in _data ? _data.entityId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
-		local scriptPath = "scripts/skills/" + _data.filename;
+		local scriptPath = ::IO.scriptFilenameByHash(::MSU.System.Tooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename).ClassNameHash);
 		local className = split(_data.filename, "/").top();
 
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
@@ -117,15 +117,7 @@
 		}
 		else
 		{
-			if (_data.filename in ::MSU.NestedTooltips.ItemObjectsByFilename)
-			{
-				item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename];
-			}
-			else
-			{
-				item = ::new("scripts/items/" + _data.filename);
-				::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename] <- item;
-			}
+			item = ::MSU.System.Tooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.ItemObjectsByFilename);
 			::NestedTooltips.NestedTooltipItems[item.getInstanceID()] <- ::MSU.asWeakTableRef(item);
 		}
 

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -78,7 +78,7 @@
 
 		if (ret == null)
 		{
-			skill = ::new(scriptPath);
+			local skill = ::MSU.System.Tooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename);
 			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
 			skill.m.Item = item;
 			ret = getNestedTooltip_safe(skill);

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -43,15 +43,7 @@
 		local item;
 		if (itemId != null)
 		{
-			local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
-			if (itemOwner == null)
-			{
-				item = ::NestedTooltips.NestedTooltipItems[itemId];
-			}
-			else
-			{
-				item = this.getItemByItemOwner(entityId, itemId, itemOwner);
-			}
+			item = this.getItemByItemOwner(entityId, itemId, "itemOwner" in _data ? _data.itemOwner : null);
 		}
 
 		if (!::MSU.isNull(item))
@@ -105,20 +97,11 @@
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		if (itemId != null)
 		{
-			local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
-			if (itemOwner == null)
-			{
-				item = ::NestedTooltips.NestedTooltipItems[itemId];
-			}
-			else
-			{
-				item = this.getItemByItemOwner("entityId" in _data ? _data.entityId : null, itemId, itemOwner);
-			}
+			item = this.getItemByItemOwner("entityId" in _data ? _data.entityId : null, itemId, "itemOwner" in _data ? _data.itemOwner : null);
 		}
 		else
 		{
 			item = ::MSU.System.Tooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.ItemObjectsByFilename);
-			::NestedTooltips.NestedTooltipItems[item.getInstanceID()] <- ::MSU.asWeakTableRef(item);
 		}
 
 		return item.getNestedTooltip();
@@ -138,6 +121,57 @@
 
 		switch (_itemOwner)
 		{
+			case null:
+				if (entity != null)
+				{
+					item = this.getItemByItemOwner(_entityId, _itemId, "entity");
+					if (item == null && entity.isPlacedOnMap())
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "ground");
+					}
+				}
+				if (item == null)
+				{
+					item = this.getItemByItemOwner(_entityId, _itemId, "stash");
+				}
+				if (item == null)
+				{
+					if (::World.Crafting.getBlueprint(_itemId) != null)
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "craft");
+						if (item == null)
+						{
+							item = this.getItemByItemOwner(_entityId, _itemId, "blueprint");
+						}
+					}
+				}
+				if (item == null)
+				{
+					if (::World.State.getTownScreen() != null && ::World.State.getTownScreen().getShopDialogModule() != null && ::World.State.getTownScreen().getShopDialogModule().getShop() != null)
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "world-town-screen-shop-dialog-module.shop");
+					}
+				}
+				if (item == null)
+				{
+					if ("CombatResultLoot" in ::Tactical && ::Tactical.CombatResultLoot != null)
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "tactical-combat-result-screen.found-loot");
+					}
+				}
+				if (item == null)
+				{
+					foreach (it in ::MSU.NestedTooltips.ItemObjectsByFilename)
+					{
+						if (typeof it != "string" && it.getInstanceID() == _itemId)
+						{
+							item = it;
+							break;
+						}
+					}
+				}
+				break;
+
 			case "entity":
 				if (entity != null)	item = entity.getItems().getItemByInstanceID(_itemId);
 				break;

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -20,7 +20,7 @@
 		// local skillId = "skillId" in _data ? _data.skillId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
 
-		local skillId = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename].getID();
+		local skillId = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.filename].getID();
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
 		local skill;
 		if (entity != null)
@@ -80,7 +80,7 @@
 
 		if (ret == null)
 		{
-			skill = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename];
+			skill = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.filename];
 			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
 			skill.m.Item = item;
 			ret = getNestedTooltip_safe(skill);
@@ -110,7 +110,7 @@
 		}
 		else
 		{
-			item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.Filename];
+			item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.filename];
 			::NestedTooltips.NestedTooltipItems[item.getInstanceID()] <- ::MSU.asWeakTableRef(item);
 		}
 

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -21,23 +21,6 @@
 		local scriptPath = ::IO.scriptFilenameByHash(::MSU.System.Tooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename).ClassNameHash);
 		local className = split(_data.filename, "/").top();
 
-		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
-		local skill;
-		if (entity != null)
-		{
-			foreach (s in entity.getSkills().m.Skills)
-			{
-				if (s.ClassName == className && !s.isGarbage() && !s.isHidden() && ::IO.scriptFilenameByHash(s.ClassNameHash) == scriptPath)
-				{
-					skill = s;
-					break;
-				}
-			}
-		}
-
-		if (skill != null)
-			return getNestedTooltip_safe(skill);
-
 		local ret;
 
 		local item;
@@ -73,6 +56,22 @@
 				if (existingItem != null)
 				{
 					dummyContainer.equip(existingItem);
+				}
+			}
+		}
+
+		if (ret == null)
+		{
+			local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
+			if (entity != null)
+			{
+				foreach (s in entity.getSkills().m.Skills)
+				{
+					if (s.ClassName == className && !s.isGarbage() && !s.isHidden() && ::IO.scriptFilenameByHash(s.ClassNameHash) == scriptPath)
+					{
+						ret = getNestedTooltip_safe(s);
+						break;
+					}
 				}
 			}
 		}

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -1,10 +1,10 @@
 ::MSU.Mod.Tooltips.setTooltips({
 	CharacterStats = ::MSU.Class.CustomTooltip(@(_data) ::TooltipEvents.general_queryUIElementTooltipData(null, "character-stats." + _data.ExtraData, null)),
 	Perk = ::MSU.Class.CustomTooltip(function(_data) {
-		local filename = _data.ExtraData;
+		local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData).filename;
 		if (filename in ::MSU.NestedTooltips.PerkIDByFilename)
 		{
-			return ::TooltipEvents.general_queryUIPerkTooltipData(null, ::MSU.NestedTooltips.PerkIDByFilename[_data.ExtraData]);
+			return ::TooltipEvents.general_queryUIPerkTooltipData(null, ::MSU.NestedTooltips.PerkIDByFilename[filename]);
 		}
 		else
 		{
@@ -13,24 +13,20 @@
 		}
 	}),
 	Skill = ::MSU.Class.CustomTooltip(function(_data) {
-		local extraData = split(_data.ExtraData, ",");
-		_data.Filename <- extraData.remove(0);
 		local original_entityId = "entityId" in _data ? _data.entityId : null;
-		_data.entityId <- null;
-		if (extraData.len() != 0)
+		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
+		if ("entityId" in _data)
 		{
-			foreach (entry in extraData)
+			if (_data.entityId == "default")
+				_data.entityId = original_entityId;
+			else if (typeof _data.entityId == "string")
 			{
-				local pair = split(entry, ":");
-				// Allow the default entityId from the tooltip stack to fall through
-				if (pair[0] == "entityId" && pair[1] == "default")
-				{
-					_data.entityId <- original_entityId;
-					continue;
-				}
-
-				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
+				_data.entityId = _data.entityId.tointeger();
 			}
+		}
+		else
+		{
+			_data.entityId <- null;
 		}
 		if ("entityId" in _data && typeof _data.entityId == "string")
 		{
@@ -39,20 +35,19 @@
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
-		local extraData = split(_data.ExtraData, ",");
-		_data.Filename <- extraData.remove(0);
-		// We want itemId to be passed via ExtraData only because a nested item hyperlink shouldn't be
-		// considered as the tooltip  of an item that is present on an entity unless specified
-		_data.itemId <- null;
-		if (extraData.len() != 0)
+		// itemId must be passed in ExtraData if it is desired to be used
+		// i.e. we don't take it from the tooltip stack
+		// Similarly any other info from the tooltip stack e.g. entityId is ignored
+		// for the purposes of item nested tooltips because we wanted the nested tooltip of the item
+		// that has been added with itemId into the NestedTooltipItems table
+		local original_entityId = "entityId" in _data ? _data.entityId : null;
+		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
+		// entityId is required for proper handling of finding item from itemOwner
+		if (!("entityId" in _data) || _data.entityId == "default")
 		{
-			foreach (entry in extraData)
-			{
-				local pair = split(entry, ":");
-				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
-			}
+			_data.entityId <- original_entityId;
 		}
-		if ("entityId" in _data && typeof _data.entityId == "string")
+		else if (typeof _data.entityId == "string")
 		{
 			_data.entityId = _data.entityId.tointeger();
 		}

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -78,7 +78,7 @@ local tooltipImageKeywords = {
 {
 	foreach (perk in ::Const.Perks.LookupMap)
 	{
-		local filename = split(perk.Script, "/").top();
+		local filename = perk.Script.slice(21); // remove "scripts/skills/perks/"
 		tooltipImageKeywords[perk.Icon] <- "Perk+" + filename;
 		::MSU.NestedTooltips.PerkIDByFilename[filename] <- perk.ID;
 	}

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -38,8 +38,8 @@
 		// itemId must be passed in ExtraData if it is desired to be used
 		// i.e. we don't take it from the tooltip stack
 		// Similarly any other info from the tooltip stack e.g. entityId is ignored
-		// for the purposes of item nested tooltips because we wanted the nested tooltip of the item
-		// that has been added with itemId into the NestedTooltipItems table
+		// for the purposes of item nested tooltips because there may be different
+		// entityId associated with different nested item tooltips
 		local original_entityId = "entityId" in _data ? _data.entityId : null;
 		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
 		// entityId is required for proper handling of finding item from itemOwner

--- a/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
@@ -1,4 +1,5 @@
 ::MSU.NestedTooltips <- {
 	ItemObjectsByFilename = {},
+	SkillObjectsByFilename = {},
 	PerkIDByFilename = {}
 };

--- a/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
@@ -1,5 +1,4 @@
 ::MSU.NestedTooltips <- {
-	SkillObjectsByFilename = {},
 	ItemObjectsByFilename = {},
 	PerkIDByFilename = {}
 };

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -1,5 +1,9 @@
 local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.]+)\] \[([^|]+)\|([\w\.]+)\]
 
+// Squirrel regex cannot match empty strings, so we require a blank 1 length string
+// instead of empty string as the default alias for "$Name$"
+local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
+
 // the __regexp should be a static member of the TooltipsModAddon class when merging into MSU
 ::MSU.Class.TooltipsModAddon.parseString <- function( _string, _prefix = "" )
 {
@@ -11,7 +15,25 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 	while (match = __regexp.capture(_string, lastPos))
 	{
 		ret += _string.slice(lastPos, match[0].begin);
+
 		local text = _string.slice(match[1].begin, match[1].end);
+		local tooltipID = _string.slice(match[2].begin, match[2].end);
+		local modID = !::MSU.System.Tooltips.hasKey(myModID, tooltipID) && ::MSU.System.Tooltips.hasKey(::MSU.ID, tooltipID) ? ::MSU.ID : myModID;
+		if (modID == ::MSU.ID)
+		{
+			local key = split(_prefix + tooltipID, "+")[0];
+			local extraData = ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data;
+
+			local fieldLastPos = 0;
+			local fieldMatch;
+			while (fieldMatch = __dynamicFieldRegexp.capture(text, fieldLastPos))
+			{
+				local field = this.generateNestedTextFromObj(text.slice(fieldMatch[1].begin, fieldMatch[1].end), key, extraData);
+				text = text.slice(0, fieldMatch[0].begin) + field + text.slice(fieldMatch[0].end);
+				fieldLastPos = fieldMatch[0].end;
+			}
+		}
+
 		if (text.find("Img/") != null)
 		{
 			text = text.slice(4);
@@ -21,14 +43,7 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 		{
 			tag = "tooltip";
 		}
-		local tooltipID = _string.slice(match[2].begin, match[2].end);
-		local modID = !::MSU.System.Tooltips.hasKey(myModID, tooltipID) && ::MSU.System.Tooltips.hasKey(::MSU.ID, tooltipID) ? ::MSU.ID : myModID;
-		// Squirrel regex cannot match empty strings, so we require a blank 1 length string
-		// instead of empty string as the default for "Obj/Name"
-		if (modID == ::MSU.ID && (text == " " || text.len() > 3 && text.slice(0, 4) == "Obj/"))
-		{
-			text = this.generateNestedTextFromObj(text == " " ? "Name" : text.slice(4), split(_prefix + tooltipID, "+")[0], ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data);
-		}
+
 		ret += format("[%s=%s.%s]%s[/%s]", tag, modID, _prefix + tooltipID, text, tag);
 		lastPos = match[0].end;
 	}
@@ -52,11 +67,19 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 	}
 
 	local isLower = false;
-	local idx = _field.find(".tolower()");
-	if (idx != null)
+
+	if (_field == " ")
 	{
-		_field = _field.slice(0, idx);
-		isLower = true;
+		_field = "Name";
+	}
+	else
+	{
+		local idx = _field.find(".tolower()");
+		if (idx != null)
+		{
+			_field = _field.slice(0, idx);
+			isLower = true;
+		}
 	}
 
 	local ret = "";

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -96,7 +96,17 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 			break;
 
 		case "Item":
-			ret = ::MSU.NestedTooltips.ItemObjectsByFilename[filename].m[_field];
+			local item;
+			if (filename in ::MSU.NestedTooltips.ItemObjectsByFilename)
+			{
+				item = ::MSU.NestedTooltips.ItemObjectsByFilename[filename];
+			}
+			else
+			{
+				item = ::new("scripts/items/" + filename);
+				::MSU.NestedTooltips.ItemObjectsByFilename[filename] <- item;
+			}
+			ret = item.m[_field];
 			break;
 	}
 

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -23,6 +23,10 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 		}
 		local tooltipID = _string.slice(match[2].begin, match[2].end);
 		local modID = !::MSU.System.Tooltips.hasKey(myModID, tooltipID) && ::MSU.System.Tooltips.hasKey(::MSU.ID, tooltipID) ? ::MSU.ID : myModID;
+		if (modID == ::MSU.ID && text.len() > 3 && text.slice(0, 4) == "Obj/")
+		{
+			text = this.generateNestedTextFromObj(text.slice(4), split(_prefix + tooltipID, "+")[0], ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data);
+		}
 		ret += format("[%s=%s.%s]%s[/%s]", tag, modID, _prefix + tooltipID, text, tag);
 		lastPos = match[0].end;
 	}
@@ -35,3 +39,18 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 	return ::MSU.System.Tooltips.setTooltipImageKeywords(this.Mod.getID(), _table);
 }
 
+::MSU.Class.TooltipsModAddon.generateNestedTextFromObj <- function( _field, _key, _extraData )
+{
+	local filename = split(_extraData, ",")[0];
+	switch (_key)
+	{
+		case "Perk":
+			return ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
+
+		case "Skill":
+			return ::MSU.NestedTooltips.SkillObjectsByFilename[filename].m[_field];
+
+		case "Item":
+			return ::MSU.NestedTooltips.ItemObjectsByFilename[filename].m[_field];
+	}
+}

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -43,6 +43,14 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 
 ::MSU.Class.TooltipsModAddon.generateNestedTextFromObj <- function( _field, _key, _extraData )
 {
+	// MSU.__canCreateDummyPlayer is flipped by us during the FirstWorldInit bucket
+	// so we can use it here to check whether that bucket has been reached.
+	if (_key != "Perk" && !::MSU.__canCreateDummyPlayer)
+	{
+		::logError("BB Objects must not be instantiated before hooks have completed, therefore object specific fields cannot be used in parseString until a FirstWorldInit bucket queued after " + ::NestedTooltips.ID)
+		throw "trying to parseString with Object fields too early"
+	}
+
 	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
 	switch (_key)
 	{

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -19,10 +19,11 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 		local text = _string.slice(match[1].begin, match[1].end);
 		local tooltipID = _string.slice(match[2].begin, match[2].end);
 		local modID = !::MSU.System.Tooltips.hasKey(myModID, tooltipID) && ::MSU.System.Tooltips.hasKey(::MSU.ID, tooltipID) ? ::MSU.ID : myModID;
-		if (modID == ::MSU.ID)
+
+		if (text.find("$") != null)
 		{
 			local key = split(_prefix + tooltipID, "+")[0];
-			local extraData = ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data;
+			local extraData = ::MSU.System.Tooltips.getFullKeyAndExtraData(_prefix + tooltipID).ExtraData
 
 			local fieldLastPos = 0;
 			local fieldMatch;
@@ -56,6 +57,11 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 	return ::MSU.System.Tooltips.setTooltipImageKeywords(this.Mod.getID(), _table);
 }
 
+// This allows mods to add custom dynamic handling for their own tooltip IDs.
+// This must be a function that returns a string and
+// matches the parameter signature of TooltipsModAddon.generateNestedTextFromObj
+::MSU.Class.TooltipsModAddon.generateNestedTextFromObjCallback <- null;
+
 ::MSU.Class.TooltipsModAddon.generateNestedTextFromObj <- function( _field, _key, _extraData )
 {
 	// MSU.__canCreateDummyPlayer is flipped by us during the FirstWorldInit bucket
@@ -79,21 +85,32 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 		_field = funcs.pop();
 	}
 
-	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
 	local ret;
-	switch (_key)
+	if (this.generateNestedTextFromObjCallback != null)
 	{
-		case "Perk":
-			ret = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
-			break;
+		if (::MSU.System.Tooltips.hasKey(this.getMod().getID(), _key))
+		{
+			ret = this.generateNestedTextFromObjCallback(_field, _key, _extraData);
+		}
+	}
 
-		case "Skill":
-			ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.SkillObjectsByFilename).m[_field];
-			break;
+	if (ret == null)
+	{
+		local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
+		switch (_key)
+		{
+			case "Perk":
+				ret = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
+				break;
 
-		case "Item":
-			ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.ItemObjectsByFilename).m[_field];
-			break;
+			case "Skill":
+				ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.SkillObjectsByFilename).m[_field];
+				break;
+
+			case "Item":
+				ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.ItemObjectsByFilename).m[_field];
+				break;
+		}
 	}
 
 	if (funcs != null)

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -48,7 +48,7 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 			return ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
 
 		case "Skill":
-			return ::MSU.NestedTooltips.SkillObjectsByFilename[filename].m[_field];
+			return ::new("scripts/skills/" + filename).m[_field];
 
 		case "Item":
 			return ::MSU.NestedTooltips.ItemObjectsByFilename[filename].m[_field];

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -82,33 +82,22 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 		}
 	}
 
-	local ret = "";
-
 	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
+	local obj;
 	switch (_key)
 	{
 		case "Perk":
-			ret = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
+			obj = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename]);
 			break;
 
 		case "Skill":
-			ret = ::new("scripts/skills/" + filename).m[_field];
+			obj = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.SkillObjectsByFilename).m;
 			break;
 
 		case "Item":
-			local item;
-			if (filename in ::MSU.NestedTooltips.ItemObjectsByFilename)
-			{
-				item = ::MSU.NestedTooltips.ItemObjectsByFilename[filename];
-			}
-			else
-			{
-				item = ::new("scripts/items/" + filename);
-				::MSU.NestedTooltips.ItemObjectsByFilename[filename] <- item;
-			}
-			ret = item.m[_field];
+			obj = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.ItemObjectsByFilename).m;
 			break;
 	}
 
-	return isLower ? ret.tolower() : ret;
+	return isLower ? obj[_field].tolower() : obj[_field];
 }

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -51,16 +51,31 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 		throw "trying to parseString with Object fields too early"
 	}
 
+	local isLower = false;
+	local idx = _field.find(".tolower()");
+	if (idx != null)
+	{
+		_field = _field.slice(0, idx);
+		isLower = true;
+	}
+
+	local ret = "";
+
 	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
 	switch (_key)
 	{
 		case "Perk":
-			return ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
+			ret = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
+			break;
 
 		case "Skill":
-			return ::new("scripts/skills/" + filename).m[_field];
+			ret = ::new("scripts/skills/" + filename).m[_field];
+			break;
 
 		case "Item":
-			return ::MSU.NestedTooltips.ItemObjectsByFilename[filename].m[_field];
+			ret = ::MSU.NestedTooltips.ItemObjectsByFilename[filename].m[_field];
+			break;
 	}
+
+	return isLower ? ret.tolower() : ret;
 }

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -41,7 +41,7 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 
 ::MSU.Class.TooltipsModAddon.generateNestedTextFromObj <- function( _field, _key, _extraData )
 {
-	local filename = split(_extraData, ",")[0];
+	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
 	switch (_key)
 	{
 		case "Perk":

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -66,7 +66,7 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 		throw "trying to parseString with Object fields too early"
 	}
 
-	local isLower = false;
+	local funcs = null;
 
 	if (_field == " ")
 	{
@@ -74,30 +74,35 @@ local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 	}
 	else
 	{
-		local idx = _field.find(".tolower()");
-		if (idx != null)
-		{
-			_field = _field.slice(0, idx);
-			isLower = true;
-		}
+		funcs = split(_field, ".");
+		funcs.reverse();
+		_field = funcs.pop();
 	}
 
 	local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_extraData).filename;
-	local obj;
+	local ret;
 	switch (_key)
 	{
 		case "Perk":
-			obj = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename]);
+			ret = ::Const.Perks.findById(::MSU.NestedTooltips.PerkIDByFilename[filename])[_field];
 			break;
 
 		case "Skill":
-			obj = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.SkillObjectsByFilename).m;
+			ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.SkillObjectsByFilename).m[_field];
 			break;
 
 		case "Item":
-			obj = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.ItemObjectsByFilename).m;
+			ret = ::MSU.System.Tooltips.getObjFromFilename(filename, ::MSU.NestedTooltips.ItemObjectsByFilename).m[_field];
 			break;
 	}
 
-	return isLower ? obj[_field].tolower() : obj[_field];
+	if (funcs != null)
+	{
+		while (funcs.len() != 0)
+		{
+			ret = compilestring(format("return @(_s) _s.%s", funcs.pop()))()(ret);
+		}
+	}
+
+	return ret;
 }

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -23,9 +23,11 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 		}
 		local tooltipID = _string.slice(match[2].begin, match[2].end);
 		local modID = !::MSU.System.Tooltips.hasKey(myModID, tooltipID) && ::MSU.System.Tooltips.hasKey(::MSU.ID, tooltipID) ? ::MSU.ID : myModID;
-		if (modID == ::MSU.ID && text.len() > 3 && text.slice(0, 4) == "Obj/")
+		// Squirrel regex cannot match empty strings, so we require a blank 1 length string
+		// instead of empty string as the default for "Obj/Name"
+		if (modID == ::MSU.ID && (text == " " || text.len() > 3 && text.slice(0, 4) == "Obj/"))
 		{
-			text = this.generateNestedTextFromObj(text.slice(4), split(_prefix + tooltipID, "+")[0], ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data);
+			text = this.generateNestedTextFromObj(text == " " ? "Name" : text.slice(4), split(_prefix + tooltipID, "+")[0], ::MSU.System.Tooltips.getTooltip(modID, _prefix + tooltipID).Data);
 		}
 		ret += format("[%s=%s.%s]%s[/%s]", tag, modID, _prefix + tooltipID, text, tag);
 		lastPos = match[0].end;

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -42,9 +42,25 @@ local ImageKeywordMap = {};
 // overwrite existing function
 ::MSU.Class.TooltipsSystem.getTooltip <- function( _modID, _identifier )
 {
+	local info = this.getFullKeyAndExtraData(_identifier);
+
+	local currentTable = this.Mods[_modID];
+	for (local i = 0; i < info.FullKey.len(); ++i)
+	{
+		local currentKey = info.FullKey[i];
+		currentTable = currentTable[currentKey];
+	}
+
+	return {
+		Tooltip = currentTable,
+		Data = info.ExtraData
+	};
+}
+
+::MSU.Class.TooltipsSystem.getFullKeyAndExtraData <- function( _identifier )
+{
 	local arr = split(_identifier, "+");
-	local fullKey = split(arr[0], ".");
-	local extraData;
+	local extraData = "";
 	switch (arr.len())
 	{
 		case 1:
@@ -52,22 +68,14 @@ local ImageKeywordMap = {};
 
 		case 2:
 			extraData = arr[1];
-			break;
 
 		default:
 			extraData = arr.slice(1).reduce(@(a, b) a + "+" + b);
-			break;
 	}
 
-	local currentTable = this.Mods[_modID];
-	for (local i = 0; i < fullKey.len(); ++i)
-	{
-		local currentKey = fullKey[i];
-		currentTable = currentTable[currentKey];
-	}
 	return {
-		Tooltip = currentTable,
-		Data = extraData
+		FullKey = split(arr[0], "."),
+		ExtraData = extraData
 	};
 }
 

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -70,3 +70,17 @@ local ImageKeywordMap = {};
 		Data = extraData
 	};
 }
+
+::MSU.Class.TooltipsSystem.parseExtraDataForNestedTooltip <- function( _extraData )
+{
+	local arr = split(_extraData, ",");
+	local ret = {
+		filename = arr[0]
+	};
+	for (local i = 1; i < arr.len(); i++) // start at idx 1 because 0 is filename and already added
+	{
+		local pair = split(arr[i], ":");
+		ret[pair[0]] <- pair[1] == "null" ? null : pair[1];
+	}
+	return ret;
+}

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -118,6 +118,10 @@ local ImageKeywordMap = {};
 	if (typeof obj == "string")
 	{
 		obj = ::new(obj);
+		if (::isKindOf(obj, "skill"))
+		{
+			obj.saveBaseValues();
+		}
 		_table[_filename] = obj;
 	}
 	return obj;

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -84,3 +84,33 @@ local ImageKeywordMap = {};
 	}
 	return ret;
 }
+
+::MSU.Class.TooltipsSystem.getObjFromFilename <- function( _filename, _table )
+{
+	local obj;
+	if (_filename in _table)
+	{
+		obj = _table[_filename];
+	}
+	else
+	{
+		local idx = _filename.find("/");
+		if (idx != null)
+		{
+			// convert "skills/actives/rotation" to "actives/rotation" and eventually "rotation"
+			obj = ::MSU.Class.TooltipsSystem.getObjFromFilename(_filename.slice(idx + 1), _table);
+		}
+	}
+
+	if (obj == null)
+	{
+		throw ::MSU.Exception.KeyNotFound(_filename);
+	}
+
+	if (typeof obj == "string")
+	{
+		obj = ::new(obj);
+		_table[_filename] = obj;
+	}
+	return obj;
+}

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -35,6 +35,23 @@
 		::Hooks.registerJS(file + ".js");
 	}
 
+	local function populateObjectsByFilename( _path, _table )
+	{
+		foreach (path in ::IO.enumerateFiles(_path))
+		{
+			local arr = split(path, "/");
+			local filename = arr.pop();
+			while (filename in _table)
+			{
+				filename = arr.pop() + "/" + filename;
+			}
+			_table[filename] <- path;
+		}
+	}
+
+	populateObjectsByFilename("scripts/skills", ::MSU.NestedTooltips.SkillObjectsByFilename);
+	populateObjectsByFilename("scripts/items", ::MSU.NestedTooltips.ItemObjectsByFilename);
+
 	::Hooks.registerJS("ui/mods/msu/nested_tooltips.js");
 	::Hooks.registerCSS("ui/mods/msu/css/nested_tooltips.css");
 });

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -2,12 +2,7 @@
 	ID = "mod_nested_tooltips",
 	Name = "Nested Tooltips Framework",
 	Version = "0.1.13",
-	GitHubURL = "https://github.com/MSUTeam/nested-tooltips",
-	NestedTooltipItems = {},
-	function addItemForNestedTooltip( _item )
-	{
-		this.NestedTooltipItems[_item.getInstanceID()] <- ::MSU.asWeakTableRef(_item);
-	}
+	GitHubURL = "https://github.com/MSUTeam/nested-tooltips"
 }
 
 ::NestedTooltips.MH <- ::Hooks.register(::NestedTooltips.ID, ::NestedTooltips.Version, ::NestedTooltips.Name);

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -41,29 +41,4 @@
 
 ::NestedTooltips.MH.queue(">mod_msu", function() {
 	::MSU.__canCreateDummyPlayer = true;
-
-	foreach (file in ::IO.enumerateFiles("scripts/skills"))
-	{
-		if (file == "scripts/skills/skill")
-			continue;
-
-		local skill = ::new(file);
-		if (::isKindOf(skill, "skill"))
-		{
-			skill.saveBaseValues();
-			::MSU.NestedTooltips.SkillObjectsByFilename[skill.ClassName] <- skill;
-		}
-	}
-
-	foreach (file in ::IO.enumerateFiles("scripts/items"))
-	{
-		if (file == "scripts/items/item")
-			continue;
-
-		local item = ::new(file);
-		if (::isKindOf(item, "item"))
-		{
-			::MSU.NestedTooltips.ItemObjectsByFilename[item.ClassName] <- item;
-		}
-	}
 }, ::Hooks.QueueBucket.FirstWorldInit);


### PR DESCRIPTION
- feat: add ability to dynamically generate text based on object field such as Name for skills and items, using `Obj/Field` notation in shorthand.
- feat!: require subfolder path for perks, items, skills
  - This allows files with the same filename to exist.
  - For perks this is the `scripts/skills/perks/` folder so they remain unchanged. Shorthand: `[Anticipation|Perk+perk_anticipation]` or `[Obj/Name|Perk+perk_anticipation]`
  - For items it is the `scripts/items/` folder so now we have `weapons/knife` instead of `knife`. Shorthand: `[Knife|Item+weapons/knife]` or `[Obj/Name|Item+weapons/knife]`
  - For skills it is the `scripts/skills` folder so now we have `effects/stunned_effect` instead of `stunned_effect`. Shorthand: `[Stunned|Skill+effects/stunned_effect]` or `[Obj/Name|Skill+effects/stunned_effect]`
  - Delete `SkillObjectsByFilename` table. Skill objects are instantiated on demand during a nested tooltip query.
  - No longer instantiate all items at the start of the game. Instead they are instantiated and added to `ItemObjectsByFilename` on demand when a nested tooltip is queried for them.