### PR TITLE
Fix tooltip overflow right

### DIFF
--- a/ui/mods/msu/nested_tooltips.js
+++ b/ui/mods/msu/nested_tooltips.js
@@ -790,6 +790,15 @@ TooltipModule.prototype.setupUITooltip = function(_targetDIV, _data)
 			offsets.left = elementOffset.left + elementWidth;	// We make the left side of the tooltip start directly right of the _targetDIV
 		}
 	}
+	else
+	{
+		// If the tooltip overlaps with the left of the game window, we change it to instead starts at the left
+		if (offsets.left < 0)
+			offsets.left = 10;
+		// If the tooltip overlaps with the right of the game window, we change it to instead end at the right side
+		else if (offsets.left + containerWidth > wnd.width())
+			offsets.left = wnd.width() - containerWidth - 10;
+	}
 
 	this.mContainer.css(offsets);
 }

--- a/ui/mods/msu/nested_tooltips.js
+++ b/ui/mods/msu/nested_tooltips.js
@@ -740,8 +740,9 @@ TooltipModule.prototype.setupUITooltip = function(_targetDIV, _data)
 {
 	MSU.TooltipModule_setupUITooltip.call(this, _targetDIV, _data);
 
-	// We do the mostly the same calculations as vanilla at first for getting the top position of our tooltip
+	// Start --- Exact copy of vanilla calculation, as our later following logic requires those values
 	if(_targetDIV === undefined) return;
+
 	var offsetY = ('yOffset' in _data) ? _data.yOffset : this.mDefaultYOffset;
 	if (offsetY !== null)
 	{
@@ -755,35 +756,38 @@ TooltipModule.prototype.setupUITooltip = function(_targetDIV, _data)
 		}
 	}
 
-	var targetOffset	= _targetDIV.offset();
+	var elementOffset	= _targetDIV.offset();
+	var elementWidth	= _targetDIV.outerWidth(true);
 	var elementHeight	= _targetDIV.outerHeight(true);
-	var containerHeight = this.mContainer.outerHeight(true);
-	// By default we want the tooltips shown on top of the UI-Element
-	var offsets = {
-		top  : targetOffset.top - containerHeight - offsetY,
-		left : targetOffset.left
+	var containerWidth	= this.mContainer.outerWidth(true);		// Width of the tooltip we want to display
+	var containerHeight = this.mContainer.outerHeight(true);	// Height of the tooltip we want to display
+
+	var offsets = {		// By default we want the tooltips to show
+		top  : elementOffset.top - containerHeight - offsetY,	// on top of the UI-Element
+		left : elementOffset.left
 	}
 
 	// If that would overflow the top of the screen, we instead display them below our cursor
 	if (offsets.top < 0)
 	{
-		offsets.top = targetOffset.top + elementHeight + offsetY;
+		offsets.top = elementOffset.top + elementHeight + offsetY;
 	}
+	// End --- Exact copy of vanilla calculation. Now our custom logic starts
 
-	// If that would overflow the bottom of the screen, we instead display it starting directly at the top of the screen
+	// Feat: When a tooltip has neither enough space above, nor below the cursor, we display it starting at the top of the game window, either left or right of the cursor
 	var wnd = this.mParent; // $(window);
 	if ((offsets.top + containerHeight + offsetY) > wnd.height())
 	{
-		offsets.top = 10;
+		offsets.top = 10;	// we display it starting at the top of the game window
 
 		// Since the tooltip will now overlap with _targetDIV and cursor, we need to move it to the left or right, depending on where we have the space for it
-		if (targetOffset.left > (wnd.width() / 2))
+		if (elementOffset.left > (wnd.width() / 2))
 		{
-			offsets.left = targetOffset.left - this.mContainer.outerWidth(true);	// We make the right side of the tooltip (this.mContainer) start directly left of the _targetDIV
+			offsets.left = elementOffset.left - containerWidth;	// We make the right side of the tooltip (this.mContainer) start directly left of the _targetDIV
 		}
 		else
 		{
-			offsets.left = targetOffset.left + _targetDIV.outerWidth(true);	// We make the left side of the tooltip start directly right of the _targetDIV
+			offsets.left = elementOffset.left + elementWidth;	// We make the left side of the tooltip start directly right of the _targetDIV
 		}
 	}
 

--- a/ui/mods/msu/nested_tooltips.js
+++ b/ui/mods/msu/nested_tooltips.js
@@ -764,7 +764,7 @@ TooltipModule.prototype.setupUITooltip = function(_targetDIV, _data)
 
 	var offsets = {		// By default we want the tooltips to show
 		top  : elementOffset.top - containerHeight - offsetY,	// on top of the UI-Element
-		left : elementOffset.left
+		left : elementOffset.left + (elementWidth / 2) - (containerWidth / 2)	// horizontally exactly in the middle of the element
 	}
 
 	// If that would overflow the top of the screen, we instead display them below our cursor


### PR DESCRIPTION
# Bug 1 - tooltip not centred by default
This bug was part of nested tooltips and caused by it for the longest time. 

## Before
![image](https://github.com/user-attachments/assets/922c42d3-130d-45b2-ab0e-35f263ebfef3)

## After
![image](https://github.com/user-attachments/assets/1423d7be-0836-4c7e-92c4-ad4cc40f360e)

# Bug 2 - tooltip overflow right
This bug slipped in with bbe1224981ad91d27c36aed8faeb233ed4d949e7

## Before
![image](https://github.com/user-attachments/assets/cab341c6-4480-4138-ba17-314a8d02346e)

## After
![image](https://github.com/user-attachments/assets/3b5dae10-0076-4189-8935-83396f2b1397)