### PR TITLE
feat: allow specifying folder path for filename of nested tooltip obj

### DIFF
--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -21,7 +21,7 @@
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
 
-		local skillId = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename].getID();
+		local skillId = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.SkillObjectsByFilename).getID();
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
 		local skill;
 		if (entity != null)
@@ -73,7 +73,7 @@
 
 		if (ret == null)
 		{
-			skill = ::MSU.NestedTooltips.SkillObjectsByFilename[_data.Filename];
+			skill = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.SkillObjectsByFilename);
 			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
 			ret = getNestedTooltip_safe(skill);
 			skill.m.Container = null;
@@ -95,7 +95,7 @@
 		}
 		else
 		{
-			item = ::MSU.NestedTooltips.ItemObjectsByFilename[_data.Filename];
+			item = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.ItemObjectsByFilename);
 		}
 
 		return item.getNestedTooltip();

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -159,7 +159,7 @@
 		{
 			foreach (itemObj in ::MSU.NestedTooltips.ItemObjectsByFilename)
 			{
-				if (itemObj.getInstanceID() == _itemId)
+				if (typeof itemObj != "string" && itemObj.getInstanceID() == _itemId)
 				{
 					item = itemObj;
 					break;

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -157,14 +157,7 @@
 
 		if (item == null && _itemId != null)
 		{
-			foreach (itemObj in ::MSU.NestedTooltips.ItemObjectsByFilename)
-			{
-				if (typeof itemObj != "string" && itemObj.getInstanceID() == _itemId)
-				{
-					item = itemObj;
-					break;
-				}
-			}
+			item = ::MSU.NestedTooltips.getItemByInstanceID(_itemId);
 		}
 
 		return item;

--- a/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
@@ -1,5 +1,30 @@
 ::MSU.NestedTooltips <- {
 	SkillObjectsByFilename = {},
 	ItemObjectsByFilename = {},
-	PerkIDByFilename = {}
+	PerkIDByFilename = {},
+
+	function getObjFromFilename( _filename, _table )
+	{
+		local obj;
+		if (_filename in _table)
+		{
+			obj = _table[_filename];
+		}
+		else
+		{
+			local idx = _filename.find("/");
+			if (idx != null)
+			{
+				// convert "skills/actives/rotation" to "actives/rotation" and eventually "rotation"
+				obj = ::MSU.NestedTooltips.getObjFromFilename(_filename.slice(idx + 1), _table);
+			}
+		}
+
+		if (obj == null)
+		{
+			throw ::MSU.Exception.KeyNotFound(_filename);
+		}
+
+		return obj;
+	}
 };

--- a/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
@@ -25,6 +25,15 @@
 			throw ::MSU.Exception.KeyNotFound(_filename);
 		}
 
+		if (typeof obj == "string")
+		{
+			obj = ::new(obj);
+			_table[_filename] = obj;
+			if (::isKindOf(obj, "skill"))
+			{
+				obj.saveBaseValues();
+			}
+		}
 		return obj;
 	}
 };

--- a/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/nested_tooltips.nut
@@ -1,6 +1,7 @@
 ::MSU.NestedTooltips <- {
 	SkillObjectsByFilename = {},
 	ItemObjectsByFilename = {},
+	ItemObjectsByInstanceID = {},
 	PerkIDByFilename = {},
 
 	function getObjFromFilename( _filename, _table )
@@ -33,7 +34,17 @@
 			{
 				obj.saveBaseValues();
 			}
+			else if (::isKindOf(obj, "item"))
+			{
+				this.ItemObjectsByInstanceID[obj.getInstanceID()] <- obj;
+			}
 		}
+
 		return obj;
+	}
+
+	function getItemByInstanceID( _id )
+	{
+		return _id in this.ItemObjectsByInstanceID ? this.ItemObjectsByInstanceID[_id] : null;
 	}
 };

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -37,28 +37,25 @@
 ::NestedTooltips.MH.queue(">mod_msu", function() {
 	::MSU.__canCreateDummyPlayer = true;
 
-	foreach (file in ::IO.enumerateFiles("scripts/skills"))
+	local function populateObjectsByFilename( _path, _table )
 	{
-		if (file == "scripts/skills/skill")
-			continue;
-
-		local skill = ::new(file);
-		if (::isKindOf(skill, "skill"))
+		foreach (path in ::IO.enumerateFiles(_path))
 		{
-			skill.saveBaseValues();
-			::MSU.NestedTooltips.SkillObjectsByFilename[skill.ClassName] <- skill;
+			local arr = split(path, "/");
+			local filename = arr.pop();
+			while (filename in _table)
+			{
+				filename = arr.pop() + "/" + filename;
+			}
+			local obj = ::new(path);
+			if (::isKindOf(obj, "skill"))
+			{
+				skill.saveBaseValues();
+			}
+			_table[filename] <- obj;
 		}
 	}
 
-	foreach (file in ::IO.enumerateFiles("scripts/items"))
-	{
-		if (file == "scripts/items/item")
-			continue;
-
-		local item = ::new(file);
-		if (::isKindOf(item, "item"))
-		{
-			::MSU.NestedTooltips.ItemObjectsByFilename[item.ClassName] <- item;
-		}
-	}
+	populateObjectsByFilename("scripts/skills", ::MSU.NestedTooltips.SkillObjectsByFilename);
+	populateObjectsByFilename("scripts/items", ::MSU.NestedTooltips.ItemObjectsByFilename);
 }, ::Hooks.QueueBucket.FirstWorldInit);

--- a/scripts/!mods_preload/mod_nested_tooltips.nut
+++ b/scripts/!mods_preload/mod_nested_tooltips.nut
@@ -30,13 +30,6 @@
 		::Hooks.registerJS(file + ".js");
 	}
 
-	::Hooks.registerJS("ui/mods/msu/nested_tooltips.js");
-	::Hooks.registerCSS("ui/mods/msu/css/nested_tooltips.css");
-});
-
-::NestedTooltips.MH.queue(">mod_msu", function() {
-	::MSU.__canCreateDummyPlayer = true;
-
 	local function populateObjectsByFilename( _path, _table )
 	{
 		foreach (path in ::IO.enumerateFiles(_path))
@@ -47,15 +40,17 @@
 			{
 				filename = arr.pop() + "/" + filename;
 			}
-			local obj = ::new(path);
-			if (::isKindOf(obj, "skill"))
-			{
-				skill.saveBaseValues();
-			}
-			_table[filename] <- obj;
+			_table[filename] <- path;
 		}
 	}
 
 	populateObjectsByFilename("scripts/skills", ::MSU.NestedTooltips.SkillObjectsByFilename);
 	populateObjectsByFilename("scripts/items", ::MSU.NestedTooltips.ItemObjectsByFilename);
+
+	::Hooks.registerJS("ui/mods/msu/nested_tooltips.js");
+	::Hooks.registerCSS("ui/mods/msu/css/nested_tooltips.css");
+});
+
+::NestedTooltips.MH.queue(">mod_msu", function() {
+	::MSU.__canCreateDummyPlayer = true;
 }, ::Hooks.QueueBucket.FirstWorldInit);


### PR DESCRIPTION
Currently we only allow specifying the filename. This does not have the capacity to handle multiple files of the same name within the same parent folder but different child folders e.g. `skills/effects/rotation` and `skills/actives/rotation` cannot be differentiated by `parseString("[Rotation|Skill+rotation]").

This PR allows specifying the path to the desired file for Skills and Items.

When no path is specified and only the filename is given, it will always take the FIRST file in order of `IO.enumerateFiles`. So existing behavior is preserved.