### PR TITLE
Feat better handling for nested tooltips of items

### DIFF
--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -17,20 +17,10 @@
 		}
 
 		local entityId = "entityId" in _data ? _data.entityId : null;
-		// local skillId = "skillId" in _data ? _data.skillId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
-
-		local skillId = ::MSU.NestedTooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename).getID();
-		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
-		local skill;
-		if (entity != null)
-		{
-			skill = entity.getSkills().getSkillByID(skillId);
-		}
-
-		if (skill != null)
-			return getNestedTooltip_safe(skill);
+		local cachedSkillObj = ::MSU.NestedTooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename);
+		local skillId = cachedSkillObj.getID();
 
 		local ret;
 
@@ -73,10 +63,19 @@
 
 		if (ret == null)
 		{
-			skill = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.SkillObjectsByFilename);
-			skill.m.Container = ::MSU.getDummyPlayer().getSkills();
-			ret = getNestedTooltip_safe(skill);
-			skill.m.Container = null;
+			local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
+			if (entity != null)
+			{
+				local skill = entity.getSkills().getSkillByID(skillId);
+				if (skill != null)
+				{
+					return getNestedTooltip_safe(skill);
+				}
+			}
+
+			cachedSkillObj.m.Container = ::MSU.getDummyPlayer().getSkills();
+			ret = getNestedTooltip_safe(cachedSkillObj);
+			cachedSkillObj.m.Container = null;
 		}
 
 		return ret;

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -108,6 +108,39 @@
 
 		switch (_itemOwner)
 		{
+			case null:
+				if (entity != null)
+				{
+					item = this.getItemByItemOwner(_entityId, _itemId, "entity");
+					if (item == null && entity.isPlacedOnMap())
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "ground");
+					}
+				}
+				if (item == null)
+				{
+					item = this.getItemByItemOwner(_entityId, _itemId, "stash");
+				}
+				if (item == null)
+				{
+					if (::World.State.getTownScreen() != null && ::World.State.getTownScreen().getShopDialogModule() != null && ::World.State.getTownScreen().getShopDialogModule().getShop() != null)
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "world-town-screen-shop-dialog-module.shop");
+					}
+				}
+				if (item == null)
+				{
+					if ("CombatResultLoot" in ::Tactical && ::Tactical.CombatResultLoot != null)
+					{
+						item = this.getItemByItemOwner(_entityId, _itemId, "tactical-combat-result-screen.found-loot");
+					}
+				}
+				if (item == null)
+				{
+					item = ::MSU.NestedTooltips.getItemByInstanceID(_itemId);
+				}
+				break;
+
 			case "entity":
 				if (entity != null)	item = entity.getItems().getItemByInstanceID(_itemId);
 				break;
@@ -122,12 +155,6 @@
 				local result = ::Stash.getItemByInstanceID(_itemId);
 				if (result != null) item = result.item;
 				break;
-
-			case "craft":
-				return ::World.Crafting.getBlueprint(_itemId).getTooltip();
-
-			case "blueprint":
-				return ::World.Crafting.getBlueprint(_entityId).getTooltipForComponent(_itemId);
 
 			case "world-town-screen-shop-dialog-module.stash":
 				local result = ::Stash.getItemByInstanceID(_itemId);
@@ -153,11 +180,6 @@
 				local result = ::Tactical.CombatResultLoot.getItemByInstanceID(_itemId);
 				if (result != null) item = result.item;
 				break;
-		}
-
-		if (item == null && _itemId != null)
-		{
-			item = ::MSU.NestedTooltips.getItemByInstanceID(_itemId);
 		}
 
 		return item;

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -21,7 +21,7 @@
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
 
-		local skillId = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.SkillObjectsByFilename).getID();
+		local skillId = ::MSU.NestedTooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.SkillObjectsByFilename).getID();
 		local entity = entityId != null ? ::Tactical.getEntityByID(entityId) : null;
 		local skill;
 		if (entity != null)
@@ -95,7 +95,7 @@
 		}
 		else
 		{
-			item = ::MSU.NestedTooltips.getObjFromFilename(_data.Filename, ::MSU.NestedTooltips.ItemObjectsByFilename);
+			item = ::MSU.NestedTooltips.getObjFromFilename(_data.filename, ::MSU.NestedTooltips.ItemObjectsByFilename);
 		}
 
 		return item.getNestedTooltip();

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -26,12 +26,20 @@
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
+		// itemId, entityId etc. must be passed in ExtraData if it is desired to be used
+		// i.e. we don't take it from the tooltip stack.
+		// Info such as entityId is ignored from the tooltip stack for the purposes of item
+		// nested tooltips because there may be different entityId associated with
+		// different nested item tooltips.
 		local original_entityId = "entityId" in _data ? _data.entityId : null;
 		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
-		// entityId is required for proper handling of finding item from itemOwner
-		if (!("entityId" in _data) || _data.entityId == "default")
+		if (!("entityId" in _data))
 		{
-			_data.entityId <- original_entityId;
+			_data.entityId <- null;
+		}
+		else if (_data.entityId == "default")
+		{
+			_data.entityId = original_entityId;
 		}
 		return ::TooltipEvents.general_queryItemNestedTooltipData(_data);
 	}),

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -1,10 +1,10 @@
 ::MSU.Mod.Tooltips.setTooltips({
 	CharacterStats = ::MSU.Class.CustomTooltip(@(_data) ::TooltipEvents.general_queryUIElementTooltipData(null, "character-stats." + _data.ExtraData, null)),
 	Perk = ::MSU.Class.CustomTooltip(function(_data) {
-		local filename = _data.ExtraData;
+		local filename = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData).filename;
 		if (filename in ::MSU.NestedTooltips.PerkIDByFilename)
 		{
-			return ::TooltipEvents.general_queryUIPerkTooltipData(null, ::MSU.NestedTooltips.PerkIDByFilename[_data.ExtraData]);
+			return ::TooltipEvents.general_queryUIPerkTooltipData(null, ::MSU.NestedTooltips.PerkIDByFilename[filename]);
 		}
 		else
 		{
@@ -13,52 +13,25 @@
 		}
 	}),
 	Skill = ::MSU.Class.CustomTooltip(function(_data) {
-		local extraData = split(_data.ExtraData, ",");
-		_data.Filename <- extraData.remove(0);
 		local original_entityId = "entityId" in _data ? _data.entityId : null;
-		_data.entityId <- null;
-		if (extraData.len() != 0)
+		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
+		if (!("entityId" in _data))
 		{
-			foreach (entry in extraData)
-			{
-				local pair = split(entry, ":");
-				// Allow the default entityId from the tooltip stack to fall through
-				if (pair[0] == "entityId" && pair[1] == "default")
-				{
-					_data.entityId <- original_entityId;
-					continue;
-				}
-
-				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
-			}
+			_data.entityId <- null;
 		}
-		// Will be string when passed manually via ExtraData in nested tooltip string
-		if (typeof _data.entityId == "string")
+		else if (_data.entityId == "default")
 		{
-			_data.entityId = _data.entityId.tointeger();
+			_data.entityId = original_entityId;
 		}
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
-		local extraData = split(_data.ExtraData, ",");
-		_data.Filename <- extraData.remove(0);
-		// We want itemId and _itemOwner to be passed via ExtraData only
-		// because a nested item hyperlink shouldn't be considered as the tooltip
-		// of an item that is present on an entity unless specified
-		_data.itemOwner <- null;
-		_data.itemId <- null;
-		if (extraData.len() != 0)
+		local original_entityId = "entityId" in _data ? _data.entityId : null;
+		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
+		// entityId is required for proper handling of finding item from itemOwner
+		if (!("entityId" in _data) || _data.entityId == "default")
 		{
-			foreach (entry in extraData)
-			{
-				local pair = split(entry, ":");
-				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
-			}
-		}
-		// Will be string when passed manually via ExtraData in nested tooltip string
-		if (typeof _data.entityId == "string")
-		{
-			_data.entityId = _data.entityId.tointeger();
+			_data.entityId <- original_entityId;
 		}
 		return ::TooltipEvents.general_queryItemNestedTooltipData(_data);
 	}),

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -15,24 +15,29 @@
 	Skill = ::MSU.Class.CustomTooltip(function(_data) {
 		local extraData = split(_data.ExtraData, ",");
 		_data.Filename <- extraData.remove(0);
+		local original_entityId = "entityId" in _data ? _data.entityId : null;
+		_data.entityId <- null;
 		if (extraData.len() != 0)
 		{
 			foreach (entry in extraData)
 			{
 				local pair = split(entry, ":");
+				// Allow the default entityId from the tooltip stack to fall through
+				if (pair[0] == "entityId" && pair[1] == "default")
+				{
+					_data.entityId <- original_entityId;
+					continue;
+				}
+
 				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
 			}
 		}
+		// Will be string when passed manually via ExtraData in nested tooltip string
+		if (typeof _data.entityId == "string")
+		{
+			_data.entityId = _data.entityId.tointeger();
+		}
 		return ::TooltipEvents.general_querySkillNestedTooltipData(_data);
-	}),
-	// Sometimes you need to show the nested tooltip by considering the entity to be null. This is useful for
-	// e.g. showing nested tooltips of StatusEffects inside perk tooltips on the perk tree window when the selected
-	// character has the StatusEffect. Using the standard Skill+filename will show the tooltip of the effect based on that character
-	// whereas we want to show a generic tooltip independent of the entity.
-	NullEntitySkill = ::MSU.Class.CustomTooltip(function(_data) {
-		_data.entityId <- ::MSU.getDummyPlayer().getID();
-		_data.itemOwner <- null;
-		return ::MSU.System.Tooltips.getTooltip(_data.modId, "Skill").Tooltip.getUIData(_data);
 	}),
 	Item = ::MSU.Class.CustomTooltip(function(_data) {
 		local extraData = split(_data.ExtraData, ",");

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -55,6 +55,11 @@
 				_data[pair[0]] <- pair[1] == "null" ? null : pair[1];
 			}
 		}
+		// Will be string when passed manually via ExtraData in nested tooltip string
+		if (typeof _data.entityId == "string")
+		{
+			_data.entityId = _data.entityId.tointeger();
+		}
 		return ::TooltipEvents.general_queryItemNestedTooltipData(_data);
 	}),
 });

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -70,3 +70,24 @@ local ImageKeywordMap = {};
 		Data = extraData
 	};
 }
+
+::MSU.Class.TooltipsSystem.parseExtraDataForNestedTooltip <- function( _extraData )
+{
+	local arr = split(_extraData, ",");
+	local ret = {
+		filename = arr[0]
+	};
+
+	for (local i = 1; i < arr.len(); i++) // start at idx 1 because 0 is filename and already added
+	{
+		local pair = split(arr[i], ":");
+		ret[pair[0]] <- pair[1] == "null" ? null : pair[1];
+	}
+
+	if ("entityId" in ret && typeof ret.entityId == "string" && ret.entityId != "default")
+	{
+		ret.entityId = ret.entityId.tointeger();
+	}
+
+	return ret;
+}


### PR DESCRIPTION
This PR is an improvement over the earlier PR of #11 which should be closed in its favor.

- [feat!: set entityId to null by default in skill nested data](https://github.com/MSUTeam/nested-tooltips/commit/48a671e553a4efae0a48af44d253bfc766096fcd)
  - This is important because we don't want skills in the entire nested tooltip stack to necessarily be linked to the first actor that spawned the tooltip stack. Instead, we now require the entityId to be manually passed and point towards the entity that you require. Passing `entityId:default` will get it from the stack.

- [feat!: improve nested tooltips item handling](https://github.com/MSUTeam/nested-tooltips/commit/0146d3d8875c469793180693323a3de79c40ee40)
  - Require the instanceID to passed in the nested tooltip ExtraData along with the entityId if applicable. Then the item is searched across the game and found and its tooltip linked to the nested tooltip. This way we achieve the goal of being able to refer to different nested objects without requiring the modder to push/add those items to a global array/table (like was necessary in #11).
  - This allows nested tooltips of items within items to work properly without getting confused about which item each tooltip is referring to. Especially the nested tooltips of items contain nested tooltips of skills which correspond to those items.

Both of these changes break existing behavior but they are necessary.