### PR TITLE
feat: add ability to specify item for skills that need one for tooltips

### DIFF
--- a/mod_nested_tooltips/hooks/items/item.nut
+++ b/mod_nested_tooltips/hooks/items/item.nut
@@ -1,4 +1,6 @@
 ::NestedTooltips.MH.hook("scripts/items/item", function(q) {
+	q.m.__MSU_IsNestedFakeItem <- false;
+
 	q.getNestedTooltip <- function()
 	{
 		return this.getTooltip();

--- a/mod_nested_tooltips/hooks/skills/skill.nut
+++ b/mod_nested_tooltips/hooks/skills/skill.nut
@@ -1,34 +1,65 @@
 ::NestedTooltips.MH.hook("scripts/skills/skill", function(q) {
+	// Can be specified and this item will then be set as the m.Item of this skill
+	// while fetching the nested tooltip, if no item is already set. This is necessary
+	// for certain skills which need to access certain things from their item during their tooltip
+	// e.g. shoot_bolt in vanilla.
+	q.m.MSU_NestedTooltipItemScript <- null;
+
 	q.getNestedTooltip <- function()
 	{
-		return this.getDefaultNestedTooltip();
+		return this.getTooltip();
 	}
 
-	q.getDefaultNestedTooltip <- function()
+	q.__MSU_getNestedTooltipSafe <- function()
 	{
-		local ret = this.getTooltip();
-		// Remove armor penetration and armor damage numbers for tooltips of nested skills not present on an actor
-		// or without a reference to an item.
-		// This ensures that nested tooltips of attack/weapon skills inside other tooltips which are meant just
-		// as a reference to the skill in general do not display any specific damage numbers as the damage numbers
-		// in actual use would be dependent on the item or character that skill would be present on.
-		if (::MSU.isNull(this.getItem()) && ::MSU.isEqual(this.getContainer(), ::MSU.getDummyPlayer().getSkills()))
+		local fakeItem;
+		if (::MSU.isNull(this.getItem()) && this.m.MSU_NestedTooltipItemScript != null)
 		{
-			foreach (i, entry in ret)
-			{
-				if (!("text" in entry)) continue;
+			fakeItem = ::new(this.m.MSU_NestedTooltipItemScript);
+			fakeItem.m.__MSU_IsNestedFakeItem = true;
+			this.setItem(fakeItem);
+		}
 
-				if (entry.id == 4 && entry.icon == "ui/icons/regular_damage.png")
+		try
+		{
+			local ret = this.getNestedTooltip();
+			this.getContainer().onQueryTooltip(this, ret); // Manually run MSU event
+
+			// Remove armor penetration and armor damage numbers for tooltips of nested skills not present on an actor
+			// or without a reference to a real item.
+			// This ensures that nested tooltips of attack/weapon skills inside other tooltips which are meant just
+			// as a reference to the skill in general do not display any specific damage numbers as the damage numbers
+			// in actual use would be dependent on the item or character that skill would be present on.
+			local isNull = ::MSU.isNull(this.getItem());
+			if (isNull && ::MSU.isEqual(this.getContainer(), ::MSU.getDummyPlayer().getSkills()) || !isNull && this.m.Item.m.__MSU_IsNestedFakeItem)
+			{
+				foreach (i, entry in ret)
 				{
-					entry.text = ::MSU.Text.colorRed((this.getDirectDamage() * 100) + "%") + " of damage ignores armor";
-				}
-				else if (entry.id == 5 && entry.icon == "ui/icons/armor_damage.png")
-				{
-					ret.remove(i);
-					break;
+					if (!("text" in entry)) continue;
+
+					if (entry.id == 4 && entry.icon == "ui/icons/regular_damage.png")
+					{
+						entry.text = ::MSU.Text.colorRed((this.getDirectDamage() * 100) + "%") + " of damage ignores armor";
+					}
+					else if (entry.id == 5 && entry.icon == "ui/icons/armor_damage.png")
+					{
+						ret.remove(i);
+						break;
+					}
 				}
 			}
+
+			if (fakeItem != null)
+			{
+				this.setItem(null);
+			}
+
+			return ret;
 		}
-		return ret;
+		catch (error)
+		{
+			::NestedTooltips.Mod.Debug.printWarning(format("Could not fetch nested tooltip for skill %s, so returning base skill tooltip. Error: %s", this.getID(), error));
+			return this.isActive() ? this.skill.getDefaultUtilityTooltip() : this.skill.getTooltip();
+		}
 	}
 });

--- a/mod_nested_tooltips/hooks/skills/skill.nut
+++ b/mod_nested_tooltips/hooks/skills/skill.nut
@@ -7,7 +7,12 @@
 	q.getDefaultNestedTooltip <- function()
 	{
 		local ret = this.getTooltip();
-		if (::MSU.isNull(this.getItem()))
+		// Remove armor penetration and armor damage numbers for tooltips of nested skills not present on an actor
+		// or without a reference to an item.
+		// This ensures that nested tooltips of attack/weapon skills inside other tooltips which are meant just
+		// as a reference to the skill in general do not display any specific damage numbers as the damage numbers
+		// in actual use would be dependent on the item or character that skill would be present on.
+		if (::MSU.isNull(this.getItem()) && ::MSU.isEqual(this.getContainer(), ::MSU.getDummyPlayer().getSkills()))
 		{
 			foreach (i, entry in ret)
 			{

--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -1,21 +1,6 @@
 ::NestedTooltips.MH.hook("scripts/ui/screens/tooltip/tooltip_events", function(q) {
 	q.general_querySkillNestedTooltipData <- function( _data )
 	{
-		local function getNestedTooltip_safe( _skill )
-		{
-			try
-			{
-				local ret = _skill.getNestedTooltip();
-				_skill.getContainer().onQueryTooltip(_skill, ret); // Manually run MSU event
-				return ret;
-			}
-			catch (error)
-			{
-				::NestedTooltips.Mod.Debug.printWarning(format("Could not fetch nested tooltip for skill %s, so returning base skill tooltip. Error: %s", _skill.getID(), error));
-				return _skill.isActive() ? _skill.skill.getDefaultUtilityTooltip() : _skill.skill.getTooltip();
-			}
-		}
-
 		local entityId = "entityId" in _data ? _data.entityId : null;
 		local itemId = "itemId" in _data ? _data.itemId : null;
 		local itemOwner = "itemOwner" in _data ? _data.itemOwner : null;
@@ -46,7 +31,7 @@
 			{
 				if (s.getID() == skillId)
 				{
-					ret = getNestedTooltip_safe(s)
+					ret = s.__MSU_getNestedTooltipSafe();
 					break;
 				}
 			}
@@ -69,12 +54,12 @@
 				local skill = entity.getSkills().getSkillByID(skillId);
 				if (skill != null)
 				{
-					return getNestedTooltip_safe(skill);
+					return skill.__MSU_getNestedTooltipSafe();
 				}
 			}
 
 			cachedSkillObj.m.Container = ::MSU.getDummyPlayer().getSkills();
-			ret = getNestedTooltip_safe(cachedSkillObj);
+			ret = cachedSkillObj.__MSU_getNestedTooltipSafe();
 			cachedSkillObj.m.Container = null;
 		}
 


### PR DESCRIPTION
It also contains a fix for the behavior where the skill damage was hidden for non-item skills present on real actors e.g. skills present on beasts such as ghoul_claws on ghouls. Now we only hide the damage numbers if the skill is present on the dummy player which is an indication that the skill is a nested tooltip in a general sense and not a nested tooltip of a specific skill on a real actor.

The new feature allows one to specify an `m.MSU_NestedTooltipItemScript` for skills and this item will be instantiated and attached to the skill during pulling its nested tooltip if the skill already wasn't attached to an item. This helps resolve issues where certain skills which **need** an item during their `getTooltip()` e.g. `shoot_bolt` can now properly return a tooltip.