### PR TITLE
fix: not unequipping bag items properly

### DIFF
--- a/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
+++ b/mod_nested_tooltips/hooks/ui/screens/tooltip/tooltip_events.nut
@@ -23,7 +23,14 @@
 			local isDummyEquipping = ::MSU.isNull(item.getContainer());
 			if (isDummyEquipping)
 			{
-				dummyContainer.unequip(existingItem);
+				if (existingItem != null)
+				{
+					if (existingItem.getCurrentSlotType() == ::Const.ItemSlot.Bag)
+						dummyContainer.removeFromBag(existingItem);
+					else
+						dummyContainer.unequip(existingItem);
+				}
+
 				dummyContainer.equip(item);
 			}
 
@@ -38,7 +45,10 @@
 
 			if (isDummyEquipping)
 			{
-				dummyContainer.unequip(item);
+				if (item.getCurrentSlotType() == ::Const.ItemSlot.Bag)
+					dummyContainer.removeFromBag(item);
+				else
+					dummyContainer.unequip(item);
 				if (existingItem != null)
 				{
 					dummyContainer.equip(existingItem);


### PR DESCRIPTION
Vanilla does not remove bagged items by calling item_container.unequip for the item.