### PR TITLE
feat: add ability to create nested tooltips of any object

### DIFF
--- a/mod_nested_tooltips/hooks/states/world_state.nut
+++ b/mod_nested_tooltips/hooks/states/world_state.nut
@@ -4,13 +4,15 @@
 		{
 			::MSU.__destroyDummyPlayer();
 			::MSU.__canCreateDummyPlayer = true;
+			::MSU.System.Tooltips.ParsedObjects.clear();
 			__original();
 		}
 
-		q.onBeforeSerialize = @(__original) function( _out )
+		q.saveCampaign = @(__original) { function saveCampaign( _campaignFileName, _campaignLabel = null )
 		{
 			::MSU.__destroyDummyPlayer();
-			__original(_out);
-		}
+			::MSU.System.Tooltips.ParsedObjects.clear();
+			__original(_campaignFileName, _campaignLabel);
+		}}.saveCampaign;
 	});
 });

--- a/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_tooltips.nut
@@ -59,6 +59,35 @@
 		if (ret != null)
 			ret.insert(0, { contentType = "entity" });
 		return ret;
+	}),
+	Obj = ::MSU.Class.CustomTooltip(function( _data ) {
+		_data = ::MSU.System.Tooltips.parseExtraDataForNestedTooltip(_data.ExtraData);
+		// It's not actually filename that's passed here, but that's what the key is called
+		// in the return from the parse function above.
+		local obj = ::MSU.System.Tooltips.ParsedObjects[_data.filename];
+
+		local ret;
+		if ("func" in _data)
+		{
+			ret = obj[_data.func]();
+		}
+		else
+		{
+			ret = obj.getTooltip();
+		}
+
+		if (ret != null && "contentType" in _data)
+		{
+			ret.insert(0, { contentType = _data.contentType });
+		}
+
+		return ret;
+	})
+	Tooltip = ::MSU.Class.CustomTooltip(function( _data ) {
+		// replace the start/end with square brackets
+		// replace the %%%% with quotation marks
+		local str = "[" + ::String.replace(_data.ExtraData.slice(1, -1), "%%%%", "\"") + "]";
+		return compilestring("return " + str)();
 	})
 });
 

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_mod_addon.nut
@@ -4,6 +4,42 @@ local __regexp = regexp("\\[([^\\[\\]]+)\\|([^\\[\\]]+)\\]"); // \[(.+?)\|([\w\.
 // instead of empty string as the default alias for "$Name$"
 local __dynamicFieldRegexp = regexp("\\$([^\\$]+)\\$");
 
+::MSU.Class.TooltipsModAddon.parseObject <- function ( _obj )
+{
+	local key = _obj + "";
+	::MSU.System.Tooltips.ParsedObjects[key] <- _obj.weakref();
+	return key;
+}
+
+::MSU.Class.TooltipsModAddon.parseTooltip <- function( _tooltip )
+{
+	local ret = "<";
+	foreach (entry in _tooltip)
+	{
+		ret += "{";
+		foreach (k, v in entry)
+		{
+			ret += k + "=";
+			switch (typeof v)
+			{
+				case "string":
+					ret += "%%%%" + v + "%%%%";
+					break;
+				case "array":
+					ret += ::MSU.Class.TooltipsModAddon.parseTooltip(v);
+					break;
+				default:
+					ret += v;
+					break;
+			}
+			ret += ",";
+		}
+		ret += "},";
+	}
+	ret = ret.slice(0, -1) + ">";
+	return ret;
+}
+
 // the __regexp should be a static member of the TooltipsModAddon class when merging into MSU
 ::MSU.Class.TooltipsModAddon.parseString <- function( _string, _prefix = "" )
 {

--- a/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
+++ b/msu/systems/tooltips/~nested_tooltips/tooltips_system.nut
@@ -1,5 +1,6 @@
 // Can be a member inside TooltipsSystem once merged into MSU
 local ImageKeywordMap = {};
+::MSU.Class.TooltipsSystem.ParsedObjects <- {};
 
 ::MSU.Class.TooltipsSystem.setTooltipImageKeywords <- function(_modID, _tooltipTable)
 {


### PR DESCRIPTION
- Any object's tooltip can now be nested.
- A tooltip can be generated and parsed into being subsequently nested (this one is rather very niche use case).