### PR TITLE
feat: add a new modsetting for an extended "hide" delay

### DIFF
--- a/msu/msu_mod/~nested_tooltips/msu_mod_settings.nut
+++ b/msu/msu_mod/~nested_tooltips/msu_mod_settings.nut
@@ -8,4 +8,5 @@ nestedTooltipsPage.addColorPickerSetting("NestedTooltips_Color", "0,35,65,1.0", 
 
 nestedTooltipsPage.addRangeSetting("showDelay", 150, 0, 1000, 5, "Show Time", "The time in milliseconds until the tooltip appears after hovering an element.");
 nestedTooltipsPage.addRangeSetting("hideDelay", 50, 0, 1000, 5, "Hide Time", "The time in milliseconds until the tooltip disappears after leaving an element.");
+nestedTooltipsPage.addRangeSetting("graceDelay", 1000, 0, 2000, 5, "Hide Time when locked", "The time in milliseconds until the tooltip disappears after leaving an element when the tooltip is locked.");
 nestedTooltipsPage.addRangeSetting("lockDelay", 500, 0, 10000, 5, "Lock Time", "The time in milliseconds until the tooltip locks and allows you to enter it with your mouse to access nested tooltips.");

--- a/ui/mods/msu/nested_tooltips.js
+++ b/ui/mods/msu/nested_tooltips.js
@@ -61,6 +61,10 @@ MSU.NestedTooltip = {
 	        return this.stack.length === 0;
 	    },
 
+	    isLocked : function() {
+	    	return this.stack.length > 0 && this.stack[0].isLocked
+	    },
+
 	    size: function() {
 	        return this.stack.length;
 	    },
@@ -100,9 +104,11 @@ MSU.NestedTooltip = {
 			"SHOW" :  function(){ return MSU.getSettingValue(MSU.ID, "showDelay")}, // default 200,
 			"HIDE" :  function(){ return MSU.getSettingValue(MSU.ID, "hideDelay")}, // default 100,
 			"LOCK" :  function(){ return MSU.getSettingValue(MSU.ID, "lockDelay")}, // default 1000,
+			"GRACE" :  function(){ return MSU.getSettingValue(MSU.ID, "graceDelay")} // default 1000,
 		},
-		setTimer : function(_type, _func)
+		setTimer : function(_type, _func, _delayType)
 		{
+			if (!_delayType) _delayType = _type;
 			if (!(_type in this.__Timers))
 			{
 				throw "Type " + _type + " not a valid MSU.NestedTooltip.Timer!"
@@ -110,7 +116,7 @@ MSU.NestedTooltip = {
 			if (this.__Timers[_type] != null) {
 				clearTimeout(this.__Timers[_type]);
 			}
-			this.__Timers[_type] = setTimeout(_func, this.__TimerDelayGetters[_type]());
+			this.__Timers[_type] = setTimeout(_func, this.__TimerDelayGetters[_delayType]());
 		},
 		cancelTimer : function(_type)
 		{
@@ -155,10 +161,16 @@ MSU.NestedTooltip = {
                 });
             }
         },
+
         onSourceLeave : function(event) {
         	MSU.NestedTooltip.Events.cancelTimer("SHOW");
         	MSU.NestedTooltip.Events.cancelTimer("HIDE");
-            MSU.NestedTooltip.Events.setTimer("HIDE", MSU.NestedTooltip.updateStack.bind(MSU.NestedTooltip));
+        	if (MSU.NestedTooltip.TooltipStack.isLocked()) {
+        		MSU.NestedTooltip.Events.setTimer("HIDE", MSU.NestedTooltip.updateStack.bind(MSU.NestedTooltip), "GRACE");
+        	}
+        	else {
+        		MSU.NestedTooltip.Events.setTimer("HIDE", MSU.NestedTooltip.updateStack.bind(MSU.NestedTooltip));
+        	}
         },
 
         onTooltipEnter : function(event)


### PR DESCRIPTION
This adds a grace period after the tooltip has locked where it will not disappear as quickly to avoid bad UX where the user doesn't move over the tooltip fast enough and it disappears